### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,15 +14,15 @@ Inference kernels = no backward pass support.
 
 #### 1 - Triton - MoE (Mixtral) GEMM for accelerating inference. Uses col major access pattern to increase locality.
 
-<img width="556" alt="moe_gemm_a100" src="https://github.com/pytorch-labs/applied-ai/assets/46302957/9eece843-b5e1-4250-a98a-3ae79dff1bc3">
+<img width="556" alt="moe_gemm_a100" src="https://github.com/meta-pytorch/applied-ai/assets/46302957/9eece843-b5e1-4250-a98a-3ae79dff1bc3">
 
 
 #### 2 - Triton - Fused Softmax for both training and inference.
 
-<img width="556" alt="softmax_fused" src="https://github.com/pytorch-labs/applied-ai/assets/46302957/de11686b-4c17-4696-857a-4f56488d6df3">
+<img width="556" alt="softmax_fused" src="https://github.com/meta-pytorch/applied-ai/assets/46302957/de11686b-4c17-4696-857a-4f56488d6df3">
 
 #### 3 - Triton - Fused RMSNorm for both training and inference. 
-[Fused RMSNorm Kernel](https://github.com/pytorch-labs/applied-ai/blob/main/kernels/triton/training/rms_norm/fused_rms_norm.py)
+[Fused RMSNorm Kernel](https://github.com/meta-pytorch/applied-ai/blob/main/kernels/triton/training/rms_norm/fused_rms_norm.py)
 
 #### Other projects from Applied AI
 


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:08.928014+00:00Z